### PR TITLE
Update blockclock output to use new Honey image

### DIFF
--- a/runthenumbers
+++ b/runthenumbers
@@ -14,7 +14,7 @@ bcmp=""
 if [[ -n $BLOCKCLOCKPASSWORD ]]; then
     bcmp = " --digest -u :${BLOCKCLOCKPASSWORD} "
 fi
-bcai="http://${BLOCKCLOCKADDR}/api/image/4/register"
+bcai="http://${BLOCKCLOCKADDR}/api/image/4/honey"
 bcao="http://${BLOCKCLOCKADDR}/api/ou_text/"
 # Output path
 OUTPATH="/home/bitcoin/.runthenumbers/"


### PR DESCRIPTION
Now using the /api/image/{n}/honey image introduced in Blockclock firmware 1.0.7 released on November 16 (https://blockclockmini.com/firmware/ChangeLog.html).
This replaces the `register` image appearing as lines intended for checking for panel alignment.